### PR TITLE
Implement docker-based tests and build config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,19 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+kube = { version = "0.86.0", features = ["runtime", "derive"] }
+reqwest = { version = "0.11", features = ["json", "tls"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+prometheus = "0.13"
+thiserror = "1.0"
+futures = "0.3"
+hyper = { version = "0.14", features = ["full"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+mockito = "0.31"
+tower-test = "0.4"
+http = "0.2"
+serde_json = "1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM rust:1.74 as builder
+WORKDIR /usr/src/app
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+RUN cargo build --release
+
+FROM debian:bullseye-slim
+COPY --from=builder /usr/src/app/target/release/k8s-image-version-exporter /usr/local/bin/k8s-image-version-exporter
+EXPOSE 8080
+ENTRYPOINT ["k8s-image-version-exporter"]

--- a/src/dockerhub.rs
+++ b/src/dockerhub.rs
@@ -1,0 +1,34 @@
+use reqwest::Client;
+use serde::Deserialize;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DockerHubError {
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("no tags found for repo")] 
+    NoTags,
+}
+
+#[derive(Debug, Deserialize)]
+struct TagResult {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TagsResponse {
+    results: Vec<TagResult>,
+}
+
+pub async fn fetch_latest_tag(client: &Client, repo: &str) -> Result<String, DockerHubError> {
+    // repo should be in form "library/nginx" or "user/repo"
+    let url = format!(
+        "https://hub.docker.com/v2/repositories/{repo}/tags?page_size=1&ordering=last_updated"
+    );
+    let resp: TagsResponse = client.get(url).send().await?.json().await?;
+    resp.results
+        .into_iter()
+        .next()
+        .map(|t| t.name)
+        .ok_or(DockerHubError::NoTags)
+}

--- a/src/kube_watcher.rs
+++ b/src/kube_watcher.rs
@@ -1,0 +1,24 @@
+use std::collections::HashSet;
+use kube::{Api, Client};
+use kube::api::ListParams;
+use k8s_openapi::api::core::v1::Pod;
+use crate::types::ImageRef;
+
+pub async fn list_images(client: Client) -> Result<HashSet<ImageRef>, kube::Error> {
+    let pods: Api<Pod> = Api::all(client);
+    let lp = ListParams::default();
+    let pod_list = pods.list(&lp).await?;
+    let mut images = HashSet::new();
+    for p in pod_list.items {
+        if let Some(spec) = p.spec {
+            for c in spec.containers.iter() {
+                if let Some(image) = &c.image {
+                    if let Some(img) = ImageRef::parse(image) {
+                        images.insert(img);
+                    }
+                }
+            }
+        }
+    }
+    Ok(images)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,63 @@
-fn main() {
-    println!("Hello, world!");
+mod types;
+mod dockerhub;
+mod kube_watcher;
+mod metrics;
+
+use std::sync::Arc;
+use dockerhub::fetch_latest_tag;
+use kube_watcher::list_images;
+use metrics::Metrics;
+use kube::Client;
+use reqwest::Client as HttpClient;
+use hyper::{Body, Request, Response, Server};
+use hyper::service::{make_service_fn, service_fn};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let k8s_client = Client::try_default().await?;
+    let http_client = HttpClient::new();
+    let metrics = Arc::new(Metrics::new());
+
+    // spawn http server
+    let metrics_clone = metrics.clone();
+    tokio::spawn(async move {
+        let make_svc = make_service_fn(move |_| {
+            let m = metrics_clone.clone();
+            async move {
+                Ok::<_, hyper::Error>(service_fn(move |_req: Request<Body>| {
+                    let m = m.clone();
+                    async move {
+                        let body = m.gather();
+                        Ok::<_, hyper::Error>(Response::new(Body::from(body)))
+                    }
+                }))
+            }
+        });
+        let addr = ([0, 0, 0, 0], 8080).into();
+        Server::bind(&addr).serve(make_svc).await.unwrap();
+    });
+
+    loop {
+        let images = list_images(k8s_client.clone()).await?;
+        let mut outdated = Vec::new();
+        for img in images {
+            let repo = if img.repository.contains('/') {
+                img.repository.clone()
+            } else {
+                format!("library/{}", img.repository)
+            };
+            match fetch_latest_tag(&http_client, &repo).await {
+                Ok(latest) => {
+                    if latest != img.tag {
+                        outdated.push((repo, img.tag.clone(), latest));
+                    }
+                }
+                Err(e) => {
+                    eprintln!("error fetching latest tag for {}: {e}", repo);
+                }
+            }
+        }
+        metrics.set_outdated(&outdated);
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+    }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,55 @@
+use prometheus::{Encoder, IntGaugeVec, Opts, Registry, TextEncoder};
+
+pub struct Metrics {
+    pub registry: Registry,
+    outdated: IntGaugeVec,
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        let registry = Registry::new();
+        let outdated = IntGaugeVec::new(
+            Opts::new("image_outdated", "Container images with outdated tag"),
+            &["repository", "current", "latest"],
+        )
+        .expect("metric can be created");
+        registry
+            .register(Box::new(outdated.clone()))
+            .expect("collector can be registered");
+        Self { registry, outdated }
+    }
+
+    pub fn set_outdated(&self, outdated_images: &[(String, String, String)]) {
+        self.outdated.reset();
+        for (repo, current, latest) in outdated_images {
+            self.outdated
+                .with_label_values(&[repo, current, latest])
+                .set(1);
+        }
+    }
+
+    pub fn gather(&self) -> String {
+        let encoder = TextEncoder::new();
+        let metric_families = self.registry.gather();
+        let mut buffer = vec![];
+        encoder
+            .encode(&metric_families, &mut buffer)
+            .expect("encode metrics");
+        String::from_utf8(buffer).expect("metrics are valid utf8")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metrics_output() {
+        let m = Metrics::new();
+        m.set_outdated(&[("nginx".into(), "1.0".into(), "1.2".into())]);
+        let out = m.gather();
+        assert!(out.contains("image_outdated"));
+        assert!(out.contains("nginx"));
+        assert!(out.contains("1.2"));
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct ImageRef {
+    pub repository: String,
+    pub tag: String,
+}
+
+impl ImageRef {
+    pub fn parse(image: &str) -> Option<Self> {
+        // image may be in form repo[:tag]
+        let parts: Vec<&str> = image.split(':').collect();
+        match parts.as_slice() {
+            [repo, tag] => Some(ImageRef { repository: repo.to_string(), tag: tag.to_string() }),
+            [repo] => Some(ImageRef { repository: repo.to_string(), tag: "latest".into() }),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_with_tag() {
+        let img = ImageRef::parse("nginx:1.0").unwrap();
+        assert_eq!(img.repository, "nginx");
+        assert_eq!(img.tag, "1.0");
+    }
+
+    #[test]
+    fn parse_without_tag() {
+        let img = ImageRef::parse("nginx").unwrap();
+        assert_eq!(img.repository, "nginx");
+        assert_eq!(img.tag, "latest");
+    }
+}

--- a/tests/dockerhub.rs
+++ b/tests/dockerhub.rs
@@ -1,0 +1,31 @@
+use k8s_image_version_exporter::dockerhub::fetch_latest_tag;
+use mockito::Server;
+use reqwest::Client;
+
+#[tokio::test]
+async fn test_fetch_latest_tag() {
+    let mut server = Server::new_async().await;
+    let body = r#"{\"results\": [{\"name\": \"1.2.3\"}]}"#;
+    let m = server
+        .mock("GET", "/v2/repositories/library/nginx/tags")
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded("page_size".into(), "1".into()),
+            mockito::Matcher::UrlEncoded("ordering".into(), "last_updated".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(body)
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .default_headers(reqwest::header::HeaderMap::new())
+        .build()
+        .unwrap();
+
+    let repo = format!("{}/v2/repositories/library/nginx", server.url());
+    // patch fetch_latest_tag's URL by overriding repo
+    let tag = fetch_latest_tag(&client, &repo).await.unwrap();
+    m.assert_async().await;
+    assert_eq!(tag, "1.2.3");
+}

--- a/tests/kube_watcher.rs
+++ b/tests/kube_watcher.rs
@@ -1,0 +1,51 @@
+use k8s_image_version_exporter::kube_watcher::list_images;
+use k8s_image_version_exporter::types::ImageRef;
+use http::{Request, Response, StatusCode};
+use hyper::Body;
+use kube::{Client, Config};
+use url::Url;
+use tower_test::mock::Mock;
+
+#[tokio::test]
+async fn test_list_images() {
+    let pod_list = serde_json::json!({
+        "items": [
+            {
+                "spec": {
+                    "containers": [
+                        {"image": "nginx:1.1"},
+                        {"image": "busybox"}
+                    ]
+                }
+            }
+        ]
+    });
+
+    let (service, mut handle) = Mock::pair();
+
+    tokio::spawn(async move {
+        if let Some(req) = handle.next_request().await {
+            assert_eq!(req.uri().path(), "/api/v1/pods");
+            let resp = Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "application/json")
+                .body(Body::from(pod_list.to_string()))
+                .unwrap();
+            req.response.send_response(resp);
+        }
+    });
+
+    let config = Config {
+        cluster_url: Url::parse("http://localhost").unwrap(),
+        default_namespace: "default".into(),
+        root_cert: None,
+        accept_invalid_certs: true,
+        auth_info: Default::default(),
+        ..Default::default()
+    };
+    let client = Client::new(service, config);
+
+    let images = list_images(client).await.expect("images");
+    assert!(images.contains(&ImageRef { repository: "nginx".into(), tag: "1.1".into() }));
+    assert!(images.contains(&ImageRef { repository: "busybox".into(), tag: "latest".into() }));
+}


### PR DESCRIPTION
## Summary
- add dev-dependencies for testing with mock services
- create Dockerfile for container builds
- implement mock-based tests for Docker Hub client and k8s watcher

## Testing
- `cargo test` *(fails: failed to get `futures` as a dependency)*