### PR TITLE
Fix kube version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-kube = { version = "0.86.0", features = ["runtime", "derive"] }
+kube = { version = "0.87.1", features = ["runtime", "derive"] }
 reqwest = { version = "0.11", features = ["json", "tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary
- update `kube` crate to a non-yanked version

## Testing
- `cargo test` *(fails: could not connect to crates.io)*