### PR TITLE
Fix build and tests with vendored dependencies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,9 +1022,12 @@ dependencies = [
 name = "k8s-image-version-exporter"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "futures",
  "http",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "k8s-openapi",
  "kube",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,15 @@ thiserror = "2.0.12"
 futures = "0.3.31"
 hyper = { version = "1.6.0", features = ["full"] }
 reqwest = { version = "0.12.15", features = ["json"] }
+bytes = "1"
+http = "1.3.1"
+hyper-util = { version = "0.1.11", features = ["tokio"] }
+http-body-util = "0.1.3"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 mockito = "1.7.0"
 tower-test = "0.4"
-http = "1.3.1"
 serde_json = "1.0.140"
 
 [source.crates-io]

--- a/src/dockerhub.rs
+++ b/src/dockerhub.rs
@@ -21,10 +21,14 @@ struct TagsResponse {
 }
 
 pub async fn fetch_latest_tag(client: &Client, repo: &str) -> Result<String, DockerHubError> {
-    // repo should be in form "library/nginx" or "user/repo"
-    let url = format!(
-        "https://hub.docker.com/v2/repositories/{repo}/tags?page_size=1&ordering=last_updated"
-    );
+    // repo can be in form "library/nginx" or a full url to the repository
+    let url = if repo.starts_with("http://") || repo.starts_with("https://") {
+        format!("{repo}/tags?page_size=1&ordering=last_updated")
+    } else {
+        format!(
+            "https://hub.docker.com/v2/repositories/{repo}/tags?page_size=1&ordering=last_updated"
+        )
+    };
     let resp: TagsResponse = client.get(url).send().await?.json().await?;
     resp.results
         .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod types;
+pub mod dockerhub;
+pub mod kube_watcher;
+pub mod metrics;

--- a/tests/dockerhub.rs
+++ b/tests/dockerhub.rs
@@ -5,7 +5,7 @@ use reqwest::Client;
 #[tokio::test]
 async fn test_fetch_latest_tag() {
     let mut server = Server::new_async().await;
-    let body = r#"{\"results\": [{\"name\": \"1.2.3\"}]}"#;
+    let body = r#"{"results": [{"name": "1.2.3"}]}"#;
     let m = server
         .mock("GET", "/v2/repositories/library/nginx/tags")
         .match_query(mockito::Matcher::AllOf(vec![


### PR DESCRIPTION
## Summary
- add library crate and vendor config
- update HTTP server for hyper v1 APIs
- fix Docker Hub URL construction
- adjust tests for upstream library changes

## Testing
- `cargo test --quiet`