### PR TITLE
Fix hyper-util feature and extend tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ hyper = { version = "1.6.0", features = ["full"] }
 reqwest = { version = "0.12.15", features = ["json"] }
 bytes = "1"
 http = "1.3.1"
-hyper-util = { version = "0.1.11", features = ["tokio"] }
+hyper-util = { version = "0.1.11", features = ["tokio", "server"] }
 http-body-util = "0.1.3"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::{convert::Infallible, sync::Arc};
 
 use bytes::Bytes;
 use http::{Request, Response};
-use http_body_util::{combinators::BoxBody, BodyExt, Full};
+use http_body_util::{BodyExt, Full};
 use hyper::{body::Incoming, service::service_fn};
 use hyper_util::{rt::{TokioExecutor, TokioIo}, server::conn::auto::Builder};
 use kube::Client;

--- a/tests/dockerhub.rs
+++ b/tests/dockerhub.rs
@@ -29,3 +29,57 @@ async fn test_fetch_latest_tag() {
     m.assert_async().await;
     assert_eq!(tag, "1.2.3");
 }
+
+#[tokio::test]
+async fn test_fetch_latest_tag_no_tags() {
+    let mut server = Server::new_async().await;
+    let body = r#"{"results": []}"#;
+    let m = server
+        .mock("GET", "/v2/repositories/library/nginx/tags")
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded("page_size".into(), "1".into()),
+            mockito::Matcher::UrlEncoded("ordering".into(), "last_updated".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(body)
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .default_headers(reqwest::header::HeaderMap::new())
+        .build()
+        .unwrap();
+
+    let repo = format!("{}/v2/repositories/library/nginx", server.url());
+    let res = fetch_latest_tag(&client, &repo).await;
+    m.assert_async().await;
+    assert!(res.is_err());
+}
+
+#[tokio::test]
+async fn test_fetch_latest_tag_plain_repo() {
+    let mut server = Server::new_async().await;
+    let body = r#"{"results": [{"name": "2.0"}]}"#;
+    let m = server
+        .mock("GET", "/v2/repositories/library/busybox/tags")
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded("page_size".into(), "1".into()),
+            mockito::Matcher::UrlEncoded("ordering".into(), "last_updated".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(body)
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .default_headers(reqwest::header::HeaderMap::new())
+        .build()
+        .unwrap();
+
+    let repo = format!("{}/v2/repositories/library/busybox", server.url());
+    let tag = fetch_latest_tag(&client, &repo).await.unwrap();
+    m.assert_async().await;
+    assert_eq!(tag, "2.0");
+}

--- a/tests/kube_watcher.rs
+++ b/tests/kube_watcher.rs
@@ -40,3 +40,60 @@ async fn test_list_images() {
     assert!(images.contains(&ImageRef { repository: "nginx".into(), tag: "1.1".into() }));
     assert!(images.contains(&ImageRef { repository: "busybox".into(), tag: "latest".into() }));
 }
+
+#[tokio::test]
+async fn test_list_images_handles_missing_spec_and_image() {
+    let pod_list = serde_json::json!({
+        "items": [
+            {},
+            {
+                "spec": {
+                    "containers": [
+                        {"image": null},
+                        {}
+                    ]
+                }
+            }
+        ]
+    });
+
+    let (service, mut handle) = mock::pair::<Request<Body>, Response<Body>>();
+
+    tokio::spawn(async move {
+        if let Some((req, send)) = handle.next_request().await {
+            assert_eq!(req.uri().path(), "/api/v1/pods");
+            let resp = Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "application/json")
+                .body(Body::from(pod_list.to_string().into_bytes()))
+                .unwrap();
+            send.send_response(resp);
+        }
+    });
+
+    let client = Client::new(service, "default");
+
+    let images = list_images(client).await.expect("images");
+    assert!(images.is_empty());
+}
+
+#[tokio::test]
+async fn test_list_images_error_response() {
+    let (service, mut handle) = mock::pair::<Request<Body>, Response<Body>>();
+
+    tokio::spawn(async move {
+        if let Some((req, send)) = handle.next_request().await {
+            assert_eq!(req.uri().path(), "/api/v1/pods");
+            let resp = Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::empty())
+                .unwrap();
+            send.send_response(resp);
+        }
+    });
+
+    let client = Client::new(service, "default");
+
+    let res = list_images(client).await;
+    assert!(res.is_err());
+}


### PR DESCRIPTION
## Summary
- enable `hyper-util`'s `server` feature so the build succeeds
- clean up unused import in `main.rs`
- add tests for Docker Hub tag fetching
- add tests for Kubernetes image listing covering more cases

## Testing
- `cargo test`