### PR TITLE
Add Kubernetes deploy config and Docker image CI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,32 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run tests
+        run: cargo test --locked --all
+      - name: Build Docker image
+        run: docker build -t $REGISTRY/$IMAGE_NAME:latest .
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Push image
+        run: docker push $REGISTRY/$IMAGE_NAME:latest

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ To run via Docker:
 docker run --rm -p 8080:8080 -v $HOME/.kube:/root/.kube k8s-image-version-exporter
 ```
 
+### Kubernetes Deployment
+
+The repository includes manifests under `deploy/` to run the exporter inside a Kubernetes cluster.
+
+```bash
+kubectl apply -f deploy/k8s.yaml
+```
+
+The deployment uses a dedicated `ServiceAccount` and RBAC permissions so the
+exporter can list pods across the cluster.
+
 ## Testing
 
 Run the Rust test suite with:

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-image-version-exporter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-image-version-exporter
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-image-version-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-image-version-exporter
+subjects:
+  - kind: ServiceAccount
+    name: k8s-image-version-exporter
+    namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-image-version-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k8s-image-version-exporter
+  template:
+    metadata:
+      labels:
+        app: k8s-image-version-exporter
+    spec:
+      serviceAccountName: k8s-image-version-exporter
+      containers:
+      - name: exporter
+        image: ghcr.io/<your-org>/k8s-image-version-exporter:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080


### PR DESCRIPTION
## Summary
- document how to run in Kubernetes
- provide deployment and RBAC manifests
- add a GitHub Actions workflow to test, build and push a Docker image

## Testing
- `cargo test`