### PR TITLE
Update Rust base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.74 as builder
+FROM rust:1.78 AS builder
 WORKDIR /usr/src/app
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src


### PR DESCRIPTION
## Summary
- use newer Rust image for Cargo lock v4 compatibility

## Testing
- `cargo test`
- `hadolint Dockerfile` *(fails: command not found)*