### PR TITLE
Fix Docker Hub push workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: kirill02102/k8s
-  IMAGE_NAME: ${{ github.repository }}
+  REGISTRY: docker.io
+  IMAGE_NAME: kirill02102/k8s-image-version-exporter
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The binary will be available at `target/release/k8s-image-version-exporter`.
 
 ### Using Docker
 ```bash
-docker build -t k8s-image-version-exporter .
+docker build -t kirill02102/k8s-image-version-exporter .
+docker push kirill02102/k8s-image-version-exporter
 ```
 
 ## Running

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -42,7 +42,7 @@ spec:
       serviceAccountName: k8s-image-version-exporter
       containers:
       - name: exporter
-        image: ghcr.io/<your-org>/k8s-image-version-exporter:latest
+        image: kirill02102/k8s-image-version-exporter:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
## Summary
- push built image to Docker Hub
- update Kubernetes manifest to use Docker Hub image
- show how to push image in the README

## Testing
- `cargo test`
- `hadolint Dockerfile` *(fails: command not found)*
- `kubeval deploy/k8s.yaml` *(fails: command not found)*