### PR TITLE
Fix DockerHub version detection

### DIFF
--- a/src/dockerhub.rs
+++ b/src/dockerhub.rs
@@ -2,6 +2,8 @@ use reqwest::Client;
 use serde::Deserialize;
 use thiserror::Error;
 
+use crate::registry::{determine_latest_tag, parse_version};
+
 #[derive(Error, Debug)]
 pub enum DockerHubError {
     #[error("http error: {0}")]
@@ -23,16 +25,25 @@ struct TagsResponse {
 pub async fn fetch_latest_tag(client: &Client, repo: &str) -> Result<String, DockerHubError> {
     // repo can be in form "library/nginx" or a full url to the repository
     let url = if repo.starts_with("http://") || repo.starts_with("https://") {
-        format!("{repo}/tags?page_size=1&ordering=last_updated")
+        format!("{repo}/tags?page_size=100&ordering=last_updated")
     } else {
         format!(
-            "https://hub.docker.com/v2/repositories/{repo}/tags?page_size=1&ordering=last_updated"
+            "https://hub.docker.com/v2/repositories/{repo}/tags?page_size=100&ordering=last_updated"
         )
     };
     let resp: TagsResponse = client.get(url).send().await?.json().await?;
-    resp.results
-        .into_iter()
-        .next()
-        .map(|t| t.name)
-        .ok_or(DockerHubError::NoTags)
+    let tags: Vec<String> = resp.results.into_iter().map(|t| t.name).collect();
+    if tags.is_empty() {
+        return Err(DockerHubError::NoTags);
+    }
+    let numeric: Vec<String> = tags
+        .iter()
+        .filter(|t| parse_version(t).is_some())
+        .cloned()
+        .collect();
+    if !numeric.is_empty() {
+        Ok(determine_latest_tag(numeric))
+    } else {
+        Ok(tags[0].clone())
+    }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -35,12 +35,12 @@ pub async fn fetch_latest_tag(client: &Client, repo: &str) -> Result<String, Reg
     Ok(determine_latest_tag(tags))
 }
 
-fn determine_latest_tag(mut tags: Vec<String>) -> String {
+pub(crate) fn determine_latest_tag(mut tags: Vec<String>) -> String {
     tags.sort_by(|a, b| compare_versions(a, b));
     tags.pop().unwrap()
 }
 
-fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
+pub(crate) fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
     let va = parse_version(a);
     let vb = parse_version(b);
     match (&va, &vb) {
@@ -51,7 +51,7 @@ fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
     }
 }
 
-fn parse_version(tag: &str) -> Option<Vec<u64>> {
+pub(crate) fn parse_version(tag: &str) -> Option<Vec<u64>> {
     let t = tag.trim_start_matches('v');
     if t.chars().all(|c| c.is_ascii_digit() || c == '.') {
         let parts: Vec<u64> = t
@@ -64,7 +64,7 @@ fn parse_version(tag: &str) -> Option<Vec<u64>> {
     }
 }
 
-fn cmp_semver(a: &Vec<u64>, b: &Vec<u64>) -> std::cmp::Ordering {
+pub(crate) fn cmp_semver(a: &Vec<u64>, b: &Vec<u64>) -> std::cmp::Ordering {
     let len = std::cmp::max(a.len(), b.len());
     for i in 0..len {
         let av = *a.get(i).unwrap_or(&0);

--- a/tests/dockerhub.rs
+++ b/tests/dockerhub.rs
@@ -9,7 +9,7 @@ async fn test_fetch_latest_tag() {
     let m = server
         .mock("GET", "/v2/repositories/library/nginx/tags")
         .match_query(mockito::Matcher::AllOf(vec![
-            mockito::Matcher::UrlEncoded("page_size".into(), "1".into()),
+            mockito::Matcher::UrlEncoded("page_size".into(), "100".into()),
             mockito::Matcher::UrlEncoded("ordering".into(), "last_updated".into()),
         ]))
         .with_status(200)
@@ -37,7 +37,7 @@ async fn test_fetch_latest_tag_no_tags() {
     let m = server
         .mock("GET", "/v2/repositories/library/nginx/tags")
         .match_query(mockito::Matcher::AllOf(vec![
-            mockito::Matcher::UrlEncoded("page_size".into(), "1".into()),
+            mockito::Matcher::UrlEncoded("page_size".into(), "100".into()),
             mockito::Matcher::UrlEncoded("ordering".into(), "last_updated".into()),
         ]))
         .with_status(200)
@@ -64,7 +64,7 @@ async fn test_fetch_latest_tag_plain_repo() {
     let m = server
         .mock("GET", "/v2/repositories/library/busybox/tags")
         .match_query(mockito::Matcher::AllOf(vec![
-            mockito::Matcher::UrlEncoded("page_size".into(), "1".into()),
+            mockito::Matcher::UrlEncoded("page_size".into(), "100".into()),
             mockito::Matcher::UrlEncoded("ordering".into(), "last_updated".into()),
         ]))
         .with_status(200)
@@ -82,4 +82,31 @@ async fn test_fetch_latest_tag_plain_repo() {
     let tag = fetch_latest_tag(&client, &repo).await.unwrap();
     m.assert_async().await;
     assert_eq!(tag, "2.0");
+}
+
+#[tokio::test]
+async fn test_fetch_latest_tag_filters_non_numeric() {
+    let mut server = Server::new_async().await;
+    let body = r#"{"results": [{"name": "stable-perl"}, {"name": "1.4"}]}"#;
+    let m = server
+        .mock("GET", "/v2/repositories/library/nginx/tags")
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded("page_size".into(), "100".into()),
+            mockito::Matcher::UrlEncoded("ordering".into(), "last_updated".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(body)
+        .create_async()
+        .await;
+
+    let client = Client::builder()
+        .default_headers(reqwest::header::HeaderMap::new())
+        .build()
+        .unwrap();
+
+    let repo = format!("{}/v2/repositories/library/nginx", server.url());
+    let tag = fetch_latest_tag(&client, &repo).await.unwrap();
+    m.assert_async().await;
+    assert_eq!(tag, "1.4");
 }


### PR DESCRIPTION
## Summary
- get more Docker Hub tags and pick the latest numeric version
- expose version helper functions from `registry` for reuse
- update tests for Docker Hub tag fetching and add new non-numeric filtering case

## Testing
- `cargo test`